### PR TITLE
Add support for functions without arguments

### DIFF
--- a/memo.nimble
+++ b/memo.nimble
@@ -1,4 +1,4 @@
-version       = "0.3.0"
+version       = "0.4.0"
 author        = "wiffel"
 description   = "Memoize Nim functions"
 license       = "Apache2"

--- a/test.nim
+++ b/test.nim
@@ -50,6 +50,11 @@ proc impure(y: int): int {.memoized.} =
   x += y
   return x
 
+proc niladic: int {.memoized.} =
+  var i {.global.} = 0
+  i+=1
+  result = i
+
 suite "memoization":
   test "recursive function memoization":
     check fastFib(40) == fib(40)
@@ -71,3 +76,6 @@ suite "memoization":
 
   test "multiple-arguments recursive function memoization":
     check xib_tup((3, 10)) == xib(3, 10)
+
+  test "function without arguments":
+    check niladic() == niladic() and niladic() == 1


### PR DESCRIPTION
The implementation so far required functions to have arguments in order
to be memoized, as their arguments were wrapped into a tuple which was
then hashed and used for lookup in a table.

To support functions without arguments the cache is instead implemented as a simple Option type.